### PR TITLE
Suggest TrilinosLA and solvers, get rid of LA namespace

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,171 @@
+#
+# The clang-format (Clang 6) style file used by deal.II.
+#
+
+AccessModifierOffset: -2
+
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+
+BinPackArguments: false
+BinPackParameters: false
+
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterExternBlock: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeComma
+BreakStringLiterals: false
+
+ColumnLimit: 80
+
+CompactNamespaces: false
+
+ConstructorInitializerIndentWidth: 2
+
+ContinuationIndentWidth: 2
+
+Cpp11BracedListStyle: true
+
+DerivePointerAlignment: false
+
+FixNamespaceComments: true
+
+IncludeBlocks: Regroup
+IncludeCategories:
+# config.h must always be first:
+  - Regex:    "deal.II/base/config.h"
+    Priority: -1
+# deal.II folders in sorted order:
+  - Regex:    "deal.II/algorithms/.*\\.h"
+    Priority: 110
+  - Regex:    "deal.II/base/.*\\.h"
+    Priority: 120
+  - Regex:    "deal.II/boost_adaptors/.*\\.h"
+    Priority: 125
+  - Regex:    "deal.II/differentiation/.*\\.h"
+    Priority: 130
+  - Regex:    "deal.II/distributed/.*\\.h"
+    Priority: 140
+  - Regex:    "deal.II/dofs/.*\\.h"
+    Priority: 150
+  - Regex:    "deal.II/fe/.*\\.h"
+    Priority: 160
+  - Regex:    "deal.II/gmsh/.*\\.h"
+    Priority: 170
+  - Regex:    "deal.II/grid/.*\\.h"
+    Priority: 180
+  - Regex:    "deal.II/hp/.*\\.h"
+    Priority: 190
+  - Regex:    "deal.II/integrators/.*\\.h"
+    Priority: 200
+  - Regex:    "deal.II/lac/.*\\.h"
+    Priority: 210
+  - Regex:    "deal.II/matrix_free/.*\\.h"
+    Priority: 220
+  - Regex:    "deal.II/meshworker/.*\\.h"
+    Priority: 230
+  - Regex:    "deal.II/multigrid/.*\\.h"
+    Priority: 240
+  - Regex:    "deal.II/non_matching/.*\\.h"
+    Priority: 250
+  - Regex:    "deal.II/numerics/.*\\.h"
+    Priority: 260
+  - Regex:    "deal.II/opencascade/.*\\.h"
+    Priority: 270
+  - Regex:    "deal.II/optimization/.*\\.h"
+    Priority: 280
+  - Regex:    "deal.II/particles/.*\\.h"
+    Priority: 290
+  - Regex:    "deal.II/physics/.*\\.h"
+    Priority: 300
+  - Regex:    "deal.II/sundials/.*\\.h"
+    Priority: 310
+# put boost right after deal:
+  - Regex: "<boost.*>"
+    Priority: 500
+# try to group PETSc headers:
+  - Regex: "<petsc.*\\.h>"
+    Priority: 1000
+# try to catch all third party headers and put them after deal.II but before
+# standard headers:
+  - Regex: "<.*\\.(h|hpp|hxx)>"
+    Priority: 2000
+# match all standard headers. Things like '#include <armadillo>' should be
+# surrounded by #ifdef checks (which will not be merged by clang-format) so they
+# should not be caught here
+  - Regex: "<[a-z_]+>"
+    Priority: 100000
+
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth: 2
+
+IndentWrappedFunctionNames: false
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+Language: Cpp
+
+MaxEmptyLinesToKeep: 3
+
+NamespaceIndentation: All
+
+PenaltyBreakBeforeFirstCallParameter: 90
+
+PointerAlignment: Right
+
+ReflowComments: true
+CommentPragmas: '( \| |\*--|<li>|@ref | @p |@param |@name |@returns |@warning |@ingroup |@author |@date |@related |@relates |@relatesalso |@deprecated |@image |@return |@brief |@attention |@copydoc |@addtogroup |@todo |@tparam |@see |@note |@skip |@skipline |@until |@line |@dontinclude |@include)'
+
+SortIncludes: true
+SortUsingDeclarations: true
+
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+Standard: Cpp11
+
+TabWidth: 2
+
+UseTab: Never

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Ingnore generated documentation
+documentation/
+.vscode/
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/ela2.cc
+++ b/ela2.cc
@@ -1,164 +1,193 @@
-#include <deal.II/base/quadrature_lib.h>
+// Deal.II
+#include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/function.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/timer.h>
-#include <deal.II/lac/generic_linear_algebra.h>
-#define FORCE_USE_OF_TRILINOS
-namespace LA
-{
-#if defined(DEAL_II_WITH_PETSC) && !defined(DEAL_II_PETSC_WITH_COMPLEX) && \
-  !(defined(DEAL_II_WITH_TRILINOS) && defined(FORCE_USE_OF_TRILINOS))
-  using namespace dealii::LinearAlgebraPETSc;
-#  define USE_PETSC_LA
-#elif defined(DEAL_II_WITH_TRILINOS)
-  using namespace dealii::LinearAlgebraTrilinos;
-#else
-#  error DEAL_II_WITH_PETSC or DEAL_II_WITH_TRILINOS required
-#endif
-} // namespace LA
-#include <deal.II/lac/vector.h>
-#include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/solver_cg.h>
-#include <deal.II/lac/affine_constraints.h>
-#include <deal.II/lac/dynamic_sparsity_pattern.h>
-#include <deal.II/grid/grid_generator.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/grid_refinement.h>
+#include <deal.II/distributed/tria.h>
+
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
-#include <deal.II/fe/fe_q.h>
-#include <deal.II/numerics/vector_tools.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/solver_bicgstab.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/trilinos_block_sparse_matrix.h>
+#include <deal.II/lac/trilinos_parallel_block_vector.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/error_estimator.h>
-#include <deal.II/base/utilities.h>
-#include <deal.II/base/conditional_ostream.h>
-#include <deal.II/base/index_set.h>
-#include <deal.II/lac/sparsity_tools.h>
-#include <deal.II/distributed/tria.h>
-#include <deal.II/distributed/grid_refinement.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include <deal.II/physics/transformations.h>
+
+// STL
+#include <cmath>
 #include <fstream>
 #include <iostream>
-#include <deal.II/base/logstream.h>
-#include <deal.II/grid/grid_tools.h>
-#include <cmath>
-#include <deal.II/physics/transformations.h>
+
+
 
 namespace elasticity
 {
-  using namespace dealii; 
+  using namespace dealii;
 
-    double E = 210.e9;
-    double nu = 0.3;
+  double E  = 210.e9;
+  double nu = 0.3;
 
-    template <int dim>
-    class SurfaceForce : public Function<dim>
-    {
-    public:
-      virtual double value(const Point<dim> & p,
-                       const unsigned int component = 0) const override;
-    };
+  template <int dim>
+  class SurfaceForce : public Function<dim>
+  {
+  public:
+    virtual double
+    value(const Point<dim> &p, const unsigned int component = 0) const override;
+  };
 
-    template <int dim>
-    double SurfaceForce<dim>::value(const Point<dim> &p, const unsigned int) const
-    {
-      // if(p(0) > 4)
-      //   return -100;//-100 *fabs(std::sin(M_PI*p(0)/5));
-      // else
-      //   return 0.;
-      return 0;
-    }
-    
-    template <int dim>
-    class lambda : public Function<dim>
-    {
-    public:
-      virtual double value(const Point<dim> & p,
-                       const unsigned int component = 0) const override;
-    };
+  template <int dim>
+  double
+  SurfaceForce<dim>::value(const Point<dim> &p, const unsigned int) const
+  {
+    // if(p(0) > 4)
+    //   return -100;//-100 *fabs(std::sin(M_PI*p(0)/5));
+    // else
+    //   return 0.;
+    return 0;
+  }
 
-    template <int dim>
-    double lambda<dim>::value(const Point<dim> &p, const unsigned int) const
-    {
-      return E/(2*(1+nu));
-      //return -(std::sin(M_PI*p(0)/15)+2);//(-0.1 * p(0) + 2.5) * 1e9;////*; 
-    }
 
-    template <int dim>
-    class mu : public Function<dim>
-    {
-    public:
-      virtual double value(const Point<dim> & p,
-                       const unsigned int component = 0) const override;
-    };
+  template <int dim>
+  class lambda : public Function<dim>
+  {
+  public:
+    virtual double
+    value(const Point<dim> &p, const unsigned int component = 0) const override;
+  };
 
-    template <int dim>
-    double mu<dim>::value(const Point<dim> &p, const unsigned int) const
-    {
-      int fr = 10;
-      return E*nu/((1+nu)*(1-2*nu)) * (0.1 * std::sin(2* fr * M_PI*p(0)/20)+1);//(-0.025*p(0)+0.75)
-    }
 
-    template <int dim>
-    const Point<dim> roty(const Point<dim> &p)
-    {
-      Point<dim> q = p;
-      if(dim == 3)
+  template <int dim>
+  double
+  lambda<dim>::value(const Point<dim> &p, const unsigned int) const
+  {
+    return E / (2 * (1 + nu));
+    // return -(std::sin(M_PI*p(0)/15)+2);//(-0.1 * p(0) + 2.5) * 1e9;////*;
+  }
+
+
+  template <int dim>
+  class mu : public Function<dim>
+  {
+  public:
+    virtual double
+    value(const Point<dim> &p, const unsigned int component = 0) const override;
+  };
+
+
+  template <int dim>
+  double
+  mu<dim>::value(const Point<dim> &p, const unsigned int) const
+  {
+    int fr = 10;
+    return E * nu / ((1 + nu) * (1 - 2 * nu)) *
+           (0.1 * std::sin(2 * fr * M_PI * p(0) / 20) + 1); //(-0.025*p(0)+0.75)
+  }
+
+
+  template <int dim>
+  const Point<dim>
+  roty(const Point<dim> &p)
+  {
+    Point<dim> q = p;
+    if (dim == 3)
       {
         // Point<dim> axis = {0,1,0};
-        // Tensor<2,dim> rot = Physics::Transformations::Rotations::rotation_matrix_3d(axis,-M_PI);
+        // Tensor<2,dim> rot =
+        // Physics::Transformations::Rotations::rotation_matrix_3d(axis,-M_PI);
         // return Point<dim>(rot*q);
-        return Point<dim> (-q(2),q(1),q(0));
-      }        
-      else
-      {       
+        return Point<dim>(-q(2), q(1), q(0));
+      }
+    else
+      {
         return q;
-      }        
-    }
+      }
+  }
 
-    template <int dim>
-    const Point<dim> backroty(const Point<dim> &p)
-    {
-      Point<dim> q = p;
-      if(dim == 3)
+
+  template <int dim>
+  const Point<dim>
+  backroty(const Point<dim> &p)
+  {
+    Point<dim> q = p;
+    if (dim == 3)
       {
         // Point<dim> axis = {0,1,0};
-        // Tensor<2,dim> rot = Physics::Transformations::Rotations::rotation_matrix_3d(axis,M_PI);
+        // Tensor<2,dim> rot =
+        // Physics::Transformations::Rotations::rotation_matrix_3d(axis,M_PI);
         // return Point<dim>(rot*q);
-        return Point<dim> (q(2),q(1),-q(0));
-      }        
-      else
-      {       
+        return Point<dim>(q(2), q(1), -q(0));
+      }
+    else
+      {
         return q;
-      }        
-    }
+      }
+  }
+
 
   template <int dim>
   class ElaProblem
   {
   public:
     ElaProblem();
-    void run();
+    void
+    run();
+
   private:
-    std::tuple<Point<dim>,Point<dim>> get_init_vert(std::vector<double> p) const;
-    void setup_system();
-    void assemble_system();
-    void solve();
-    void refine_grid();
-    void output_results(const unsigned int cycle) const;
-    MPI_Comm mpi_communicator;
+    std::tuple<Point<dim>, Point<dim>>
+    get_init_vert(std::vector<double> p) const;
+    void
+    setup_system();
+    void
+    assemble_system();
+    void
+    solve();
+    void
+    refine_grid();
+    void
+                                              output_results(const unsigned int cycle) const;
+    MPI_Comm                                  mpi_communicator;
     parallel::distributed::Triangulation<dim> triangulation;
-    FESystem<dim>       fe;
-    DoFHandler<dim> dof_handler;
-    IndexSet locally_owned_dofs;
-    IndexSet locally_relevant_dofs;
-    AffineConstraints<double> constraints;
-    LA::MPI::SparseMatrix system_matrix;
-    LA::MPI::SparseMatrix preconditioner_matrix;
-    LA::MPI::Vector       locally_relevant_solution;
-    LA::MPI::Vector       system_rhs;
-    ConditionalOStream pcout;
-    TimerOutput        computing_timer;
-    const bool direct_solver;
+    FESystem<dim>                             fe;
+    DoFHandler<dim>                           dof_handler;
+    IndexSet                                  locally_owned_dofs;
+    IndexSet                                  locally_relevant_dofs;
+    AffineConstraints<double>                 constraints;
+    TrilinosWrappers::SparseMatrix            system_matrix;
+    TrilinosWrappers::SparseMatrix            preconditioner_matrix;
+    TrilinosWrappers::MPI::Vector             locally_relevant_solution;
+    TrilinosWrappers::MPI::Vector             system_rhs;
+    ConditionalOStream                        pcout;
+    TimerOutput                               computing_timer;
+    const bool                                direct_solver;
   };
+
+
   template <int dim>
   ElaProblem<dim>::ElaProblem()
     : mpi_communicator(MPI_COMM_WORLD)
@@ -174,19 +203,24 @@ namespace elasticity
                       pcout,
                       TimerOutput::summary,
                       TimerOutput::wall_times)
-    , direct_solver(true)
+    , direct_solver(false)
   {}
+
+
   template <int dim>
-  std::tuple<Point<dim>,Point<dim>> ElaProblem<dim>::get_init_vert(std::vector<double> p) const
+  std::tuple<Point<dim>, Point<dim>>
+  ElaProblem<dim>::get_init_vert(std::vector<double> p) const
   {
     Point<dim> p1_tmp, p2_tmp;
     for (int i = 0; i < dim; ++i)
-      p1_tmp(i) = p[i], p2_tmp(i) = p[dim+i];
-    return {p1_tmp,p2_tmp};
+      p1_tmp(i) = p[i], p2_tmp(i) = p[dim + i];
+    return {p1_tmp, p2_tmp};
   }
-  
+
+
   template <int dim>
-  void ElaProblem<dim>::setup_system()
+  void
+  ElaProblem<dim>::setup_system()
   {
     TimerOutput::Scope t(computing_timer, "setup");
     dof_handler.distribute_dofs(fe);
@@ -202,13 +236,15 @@ namespace elasticity
 
     // for (auto &face : triangulation.active_face_iterators())
     //   {
-    //     if (face->at_boundary() && (face->center()[0] < 1) && (face->center()[0] > -1)
-    //           && (face->center()[1] < 1) && (face->center()[1] > -1) && (face->boundary_id() == 1))
+    //     if (face->at_boundary() && (face->center()[0] < 1) &&
+    //     (face->center()[0] > -1)
+    //           && (face->center()[1] < 1) && (face->center()[1] > -1) &&
+    //           (face->boundary_id() == 1))
     //     {
     //       face->set_boundary_id(100);
     //     }
     //   }
-      
+
 
     VectorTools::interpolate_boundary_values(dof_handler,
                                              0,
@@ -218,192 +254,209 @@ namespace elasticity
     constraints.close();
     DynamicSparsityPattern dsp(locally_relevant_dofs);
     DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(dsp,
-                                               Utilities::MPI::all_gather(mpi_communicator,dof_handler.n_locally_owned_dofs()),
-                                               mpi_communicator,
-                                               locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(
+      dsp,
+      Utilities::MPI::all_gather(mpi_communicator,
+                                 dof_handler.n_locally_owned_dofs()),
+      mpi_communicator,
+      locally_relevant_dofs);
     system_matrix.reinit(locally_owned_dofs,
                          locally_owned_dofs,
                          dsp,
                          mpi_communicator);
 
     preconditioner_matrix.clear();
-    preconditioner_matrix.reinit(locally_owned_dofs,
-                                   dsp,
-                                   mpi_communicator);
+    preconditioner_matrix.reinit(locally_owned_dofs, dsp, mpi_communicator);
   }
+
+
   template <int dim>
-  void ElaProblem<dim>::assemble_system()
+  void
+  ElaProblem<dim>::assemble_system()
   {
-    TimerOutput::Scope t(computing_timer, "assembly");
-    const QGauss<dim> quadrature_formula(fe.degree + 1);
+    TimerOutput::Scope    t(computing_timer, "assembly");
+    const QGauss<dim>     quadrature_formula(fe.degree + 1);
     const QGauss<dim - 1> face_quadrature_formula(fe.degree + 1);
-    FEValues<dim> fe_values(fe,
+    FEValues<dim>         fe_values(fe,
                             quadrature_formula,
                             update_values | update_gradients |
                               update_quadrature_points | update_JxW_values);
-    FEFaceValues<dim> fe_face_values(fe,
-                                 face_quadrature_formula,
-                                 update_values | update_quadrature_points |
-                                   update_normal_vectors |
-                                   update_JxW_values);                          
-    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
-    const unsigned int n_q_points    = quadrature_formula.size();
-    const unsigned int n_face_q_points = face_quadrature_formula.size();
-    std::vector<double> lambda_values(n_q_points);
-    std::vector<double> mu_values(n_q_points);
-    lambda<dim> lambda;
-    mu<dim> mu;
-    FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
-    Vector<double>     cell_rhs(dofs_per_cell);
-    Vector<double>     cell_rhs_tmp(dofs_per_cell);
-    const double rhs_value = -9.81 * 7.85e3;
-    SurfaceForce<dim> surface_force;
+    FEFaceValues<dim>     fe_face_values(fe,
+                                     face_quadrature_formula,
+                                     update_values | update_quadrature_points |
+                                       update_normal_vectors |
+                                       update_JxW_values);
+    const unsigned int    dofs_per_cell   = fe.n_dofs_per_cell();
+    const unsigned int    n_q_points      = quadrature_formula.size();
+    const unsigned int    n_face_q_points = face_quadrature_formula.size();
+    std::vector<double>   lambda_values(n_q_points);
+    std::vector<double>   mu_values(n_q_points);
+    lambda<dim>           lambda;
+    mu<dim>               mu;
+    FullMatrix<double>    cell_matrix(dofs_per_cell, dofs_per_cell);
+    Vector<double>        cell_rhs(dofs_per_cell);
+    Vector<double>        cell_rhs_tmp(dofs_per_cell);
+    const double          rhs_value = -9.81 * 7.85e3;
+    SurfaceForce<dim>     surface_force;
     std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
     for (const auto &cell : dof_handler.active_cell_iterators())
-    {   
-      if (cell->is_locally_owned())
-        {
-          cell_matrix = 0.;
-          cell_rhs    = 0.;
-          fe_values.reinit(cell);
-          lambda.value_list(fe_values.get_quadrature_points(), lambda_values);
-          mu.value_list(fe_values.get_quadrature_points(), mu_values);
-          for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+      {
+        if (cell->is_locally_owned())
           {
-          for (unsigned int i = 0 ; i < fe.dofs_per_cell; ++i)
-          {
-            const unsigned int component_i =
-              fe.system_to_component_index(i).first;
-            for (unsigned int j = 0 ; j < fe.dofs_per_cell; ++j)
+            cell_matrix = 0.;
+            cell_rhs    = 0.;
+            fe_values.reinit(cell);
+            lambda.value_list(fe_values.get_quadrature_points(), lambda_values);
+            mu.value_list(fe_values.get_quadrature_points(), mu_values);
+            for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
               {
-                const unsigned int component_j =
-                  fe.system_to_component_index(j).first;
-                    cell_matrix(i, j) +=
-                      (                                                  
-                        (fe_values.shape_grad(i, q_point)[component_i] * 
-                         fe_values.shape_grad(j, q_point)[component_j] * 
-                         lambda_values[q_point])                         
-                        +                                                
-                        (fe_values.shape_grad(i, q_point)[component_j] * 
-                         fe_values.shape_grad(j, q_point)[component_i] * 
-                         mu_values[q_point])                             
-                        +                                                
-                        ((component_i == component_j) ?        
-                           (fe_values.shape_grad(i, q_point) * 
-                            fe_values.shape_grad(j, q_point) * 
-                            mu_values[q_point]) :              
-                           0)                                  
-                        ) *                                    
+                for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+                  {
+                    const unsigned int component_i =
+                      fe.system_to_component_index(i).first;
+                    for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+                      {
+                        const unsigned int component_j =
+                          fe.system_to_component_index(j).first;
+                        cell_matrix(i, j) +=
+                          ((fe_values.shape_grad(i, q_point)[component_i] *
+                            fe_values.shape_grad(j, q_point)[component_j] *
+                            lambda_values[q_point]) +
+                           (fe_values.shape_grad(i, q_point)[component_j] *
+                            fe_values.shape_grad(j, q_point)[component_i] *
+                            mu_values[q_point]) +
+                           ((component_i == component_j) ?
+                              (fe_values.shape_grad(i, q_point) *
+                               fe_values.shape_grad(j, q_point) *
+                               mu_values[q_point]) :
+                              0)) *
+                          fe_values.JxW(q_point);
+                      }
+                    cell_rhs(i) +=
+                      fe_values.shape_value_component(i, q_point, component_i) *
+                      ((component_i == dim - 1) ? rhs_value : 0.) *
                       fe_values.JxW(q_point);
-                                     
-              }
-                cell_rhs(i) += fe_values.shape_value_component(i, q_point, component_i) *
-                                ((component_i == dim-1) ? rhs_value : 0.) *
-                                fe_values.JxW(q_point);
-          }
-          cell_rhs_tmp = cell_rhs;
-
-          
-        }
-        for (unsigned int face_number = 0;
-             face_number < GeometryInfo<dim>::faces_per_cell;
-             ++face_number)
-            if (cell->face(face_number)->at_boundary() && (cell->face(face_number)->boundary_id() == 4))
-            {
-                fe_face_values.reinit(cell, face_number);
-                  for (unsigned int q_point = 0; q_point < n_face_q_points;
-                        ++q_point)
-                {
-                    const double neumann_value =
-                        surface_force.value(
-                            fe_face_values.quadrature_point(q_point));// *
-                            //fe_face_values.normal_vector(q_point));
-                    for (unsigned int i = 0; i < dofs_per_cell; ++i)
-                        cell_rhs(i) +=
-                            (fe_face_values.shape_value(i, q_point) * // phi_i(x_q)
-                            neumann_value *                          // g(x_q)
-                            fe_face_values.JxW(q_point));            // dx
                   }
+                cell_rhs_tmp = cell_rhs;
               }
-          cell->get_dof_indices(local_dof_indices);
-          constraints.distribute_local_to_global(cell_matrix,
-                                                 cell_rhs,
-                                                 local_dof_indices,
-                                                 system_matrix,
-                                                 system_rhs);
-    }
-    }
+            for (unsigned int face_number = 0;
+                 face_number < GeometryInfo<dim>::faces_per_cell;
+                 ++face_number)
+              if (cell->face(face_number)->at_boundary() &&
+                  (cell->face(face_number)->boundary_id() == 4))
+                {
+                  fe_face_values.reinit(cell, face_number);
+                  for (unsigned int q_point = 0; q_point < n_face_q_points;
+                       ++q_point)
+                    {
+                      const double neumann_value = surface_force.value(
+                        fe_face_values.quadrature_point(q_point)); // *
+                      // fe_face_values.normal_vector(q_point));
+                      for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                        cell_rhs(i) +=
+                          (fe_face_values.shape_value(i,
+                                                      q_point) * // phi_i(x_q)
+                           neumann_value *                       // g(x_q)
+                           fe_face_values.JxW(q_point));         // dx
+                    }
+                }
+            cell->get_dof_indices(local_dof_indices);
+            constraints.distribute_local_to_global(cell_matrix,
+                                                   cell_rhs,
+                                                   local_dof_indices,
+                                                   system_matrix,
+                                                   system_rhs);
+          }
+      }
     system_matrix.compress(VectorOperation::add);
     system_rhs.compress(VectorOperation::add);
   }
-  
+
+
   template <int dim>
-  void ElaProblem<dim>::solve()
+  void
+  ElaProblem<dim>::solve()
   {
     if (direct_solver)
-    {
-          TimerOutput::Scope t(computing_timer,
-                         "parallel sparse direct solver (MUMPS)");
-      TrilinosWrappers::MPI::Vector completely_distributed_solution(
-        locally_owned_dofs, mpi_communicator);
-      SolverControl                  solver_control;
-      TrilinosWrappers::SolverDirect solver(solver_control);
-      solver.initialize(system_matrix);
-      solver.solve(system_matrix, completely_distributed_solution, system_rhs);
-
-      pcout << "   Solved in with parallel sparse direct solver (MUMPS)."
-          << std::endl;
-
-      constraints.distribute(completely_distributed_solution);
-
-      locally_relevant_solution = completely_distributed_solution;
-    }
-    else
-    {
-      TimerOutput::Scope t(computing_timer, "solve");
-      TrilinosWrappers::MPI::Vector    completely_distributed_solution(locally_owned_dofs,
-                                                    mpi_communicator);
-      //SolverControl solver_control((1000 * dof_handler.n_dofs()), 1e-12);
-      unsigned int n_iterations = dof_handler.n_dofs();
-      const double solver_tolerance = 1e-8 * system_rhs.l2_norm();
-      SolverControl solver_control(
-            /* n_max_iter */ n_iterations,
-           solver_tolerance,
-           /* log_history */ true,
-           /* log_result */ true);
-
-      TrilinosWrappers::SolverCG solver(solver_control);
-      TrilinosWrappers::PreconditionSSOR preconditioner;
-      //LA::MPI::PreconditionJacobi::AdditionalData data;
-
-      preconditioner.initialize(system_matrix);
-      try
       {
+        TimerOutput::Scope t(computing_timer,
+                             "parallel sparse direct solver (MUMPS)");
+
+        pcout << "   Using direct solver..." << std::endl;
+
+        TrilinosWrappers::MPI::Vector completely_distributed_solution(
+          locally_owned_dofs, mpi_communicator);
+        SolverControl                  solver_control;
+        TrilinosWrappers::SolverDirect solver(solver_control);
+        solver.initialize(system_matrix);
         solver.solve(system_matrix,
-                   completely_distributed_solution,
-                   system_rhs,
-                   preconditioner);
+                     completely_distributed_solution,
+                     system_rhs);
+
+        pcout << "   Solved in with parallel sparse direct solver (MUMPS)."
+              << std::endl;
+
+        constraints.distribute(completely_distributed_solution);
+
+        locally_relevant_solution = completely_distributed_solution;
       }
-      catch (std::exception &e)
+    else
       {
-        Assert(false, ExcMessage(e.what()));
+        TimerOutput::Scope t(computing_timer, "solve");
+
+        pcout << "   Using iterative solver..." << std::endl;
+
+        TrilinosWrappers::MPI::Vector completely_distributed_solution(
+          locally_owned_dofs, mpi_communicator);
+
+        unsigned int  n_iterations     = dof_handler.n_dofs();
+        const double  solver_tolerance = 1e-8 * system_rhs.l2_norm();
+        SolverControl solver_control(
+          /* n_max_iter */ n_iterations,
+          solver_tolerance,
+          /* log_history */ true,
+          /* log_result */ true);
+
+        TrilinosWrappers::SolverCG solver(solver_control);
+
+        TrilinosWrappers::PreconditionSSOR                 preconditioner;
+        TrilinosWrappers::PreconditionSSOR::AdditionalData data(
+          /* over relaxation */ 1.2);
+
+        // TrilinosWrappers::PreconditionBlockJacobi preconditioner;
+        // TrilinosWrappers::PreconditionBlockJacobi::AdditionalData data;
+
+        // TrilinosWrappers::PreconditionAMG                 preconditioner;
+        // TrilinosWrappers::PreconditionAMG::AdditionalData data;
+
+        preconditioner.initialize(system_matrix, data);
+
+        try
+          {
+            solver.solve(system_matrix,
+                         completely_distributed_solution,
+                         system_rhs,
+                         preconditioner);
+          }
+        catch (std::exception &e)
+          {
+            Assert(false, ExcMessage(e.what()));
+          }
+
+        pcout << "   Solved (iteratively) in " << solver_control.last_step()
+              << " iterations." << std::endl;
+        constraints.distribute(completely_distributed_solution);
+        locally_relevant_solution = completely_distributed_solution;
       }
-      pcout << "   Solved in " << solver_control.last_step() << " iterations."
-          << std::endl;
-      constraints.distribute(completely_distributed_solution);
-      locally_relevant_solution = completely_distributed_solution;
-    }
-
-    
-    
-
   }
+
+
   template <int dim>
-  void ElaProblem<dim>::refine_grid()
+  void
+  ElaProblem<dim>::refine_grid()
   {
     TimerOutput::Scope t(computing_timer, "refine");
-    Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
+    Vector<float>      estimated_error_per_cell(triangulation.n_active_cells());
     KellyErrorEstimator<dim>::estimate(
       dof_handler,
       QGauss<dim - 1>(fe.degree + 1),
@@ -414,8 +467,11 @@ namespace elasticity
       triangulation, estimated_error_per_cell, 0.3, 0.03);
     triangulation.execute_coarsening_and_refinement();
   }
+
+
   template <int dim>
-  void ElaProblem<dim>::output_results(const unsigned int cycle) const
+  void
+  ElaProblem<dim>::output_results(const unsigned int cycle) const
   {
     DataOut<dim> data_out;
     data_out.attach_dof_handler(dof_handler);
@@ -437,14 +493,14 @@ namespace elasticity
         default:
           Assert(false, ExcNotImplemented());
       }
-    
+
     data_out.add_data_vector(locally_relevant_solution, solution_names);
 
-    std::vector<std::string> solution_name(dim,"displacement");
+    std::vector<std::string> solution_name(dim, "displacement");
     std::vector<DataComponentInterpretation::DataComponentInterpretation>
-      interpretation(
-        dim, DataComponentInterpretation::component_is_part_of_vector);
-    
+      interpretation(dim,
+                     DataComponentInterpretation::component_is_part_of_vector);
+
     data_out.add_data_vector(locally_relevant_solution,
                              solution_name,
                              DataOut<dim>::type_dof_data,
@@ -453,8 +509,8 @@ namespace elasticity
     Vector<float> subdomain(triangulation.n_active_cells());
     for (unsigned int i = 0; i < subdomain.size(); ++i)
       subdomain(i) = triangulation.locally_owned_subdomain();
-    data_out.add_data_vector(subdomain, "subdomain");  
-    
+    data_out.add_data_vector(subdomain, "subdomain");
+
     data_out.build_patches();
 
     const std::string filename =
@@ -478,39 +534,39 @@ namespace elasticity
         data_out.write_pvtu_record(master_output, filenames);
       }
   }
+
+
   template <int dim>
-  void ElaProblem<dim>::run()
+  void
+  ElaProblem<dim>::run()
   {
     pcout << "Running with "
-#ifdef USE_PETSC_LA
-          << "PETSc"
-#else
           << "Trilinos"
-#endif
           << " on " << Utilities::MPI::n_mpi_processes(mpi_communicator)
           << " MPI rank(s)..." << std::endl;
 
-    const auto [p1, p2] = get_init_vert({-10, 0, 0, 10, 1, 1});
+    const auto [p1, p2]         = get_init_vert({-10, 0, 0, 10, 1, 1});
     const unsigned int n_cycles = 1;
     for (unsigned int cycle = 0; cycle < n_cycles; ++cycle)
       {
         pcout << "Cycle " << cycle << ':' << std::endl;
         if (cycle == 0)
           {
-            const std::vector< unsigned int > repetitions = {20, 1, 1};
-            GridGenerator::subdivided_hyper_rectangle(triangulation, repetitions, p1, p2, true);
+            const std::vector<unsigned int> repetitions = {20, 1, 1};
+            GridGenerator::subdivided_hyper_rectangle(
+              triangulation, repetitions, p1, p2, true);
 
-            //GridGenerator::cylinder(triangulation, 10., 0.1);
+            // GridGenerator::cylinder(triangulation, 10., 0.1);
 
-            triangulation.refine_global(4);
+            triangulation.refine_global(2);
           }
         else
-        {
-          //GridTools::transform(backroty<dim>, triangulation);
-          refine_grid();          
-        }
+          {
+            // GridTools::transform(backroty<dim>, triangulation);
+            refine_grid();
+          }
 
-        //GridTools::transform(roty<dim>, triangulation); 
+        // GridTools::transform(roty<dim>, triangulation);
         setup_system();
         pcout << "   Number of active cells:       "
               << triangulation.n_global_active_cells() << std::endl
@@ -528,15 +584,22 @@ namespace elasticity
         pcout << std::endl;
       }
   }
-} // namespace Step40
-int main(int argc, char *argv[])
+} // namespace elasticity
+
+
+int
+main(int argc, char *argv[])
 {
   try
     {
       using namespace dealii;
       using namespace elasticity;
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
       deallog.depth_console(2);
+
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(
+        argc, argv, dealii::numbers::invalid_unsigned_int);
+
       ElaProblem<3> Ela_problem_3d;
       Ela_problem_3d.run();
     }


### PR DESCRIPTION
Hi, I suggest some changes - nothing serious. 

* I guess it would be good to get rid of the LA namespace
* I added a gitignore and an indentation file. for the latter you need `clang-format` (from package manager)
* About the solvers one needs to talk. 